### PR TITLE
Allow [spoiler] without title

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -95,7 +95,7 @@ return [
                '<p class="space"></p>'
             );
              $config->BBCodes->addCustom(
-               '[spoiler="{ANYTHING2}"]{ANYTHING3}[/spoiler]',
+               '[spoiler={ANYTHING2;optional;defaultValue=Spoiler}]{ANYTHING3}[/spoiler]',
                '<details>
                 <summary>{ANYTHING2}</summary>
                 <p>{ANYTHING3}</p>


### PR DESCRIPTION
I use your plugin for an old forum (2010) that had a spoiler tag and was migrated to Flarum. But these spoilers had no title, so your spoilers are not usable.

Modifying the hundreds, thousands, of posts using spoilers being not really possible, I added a default title, so that writing this is valid:

```[spoiler]text[/spoiler]```

The title defaults to “Spoiler” in this case.

Thanks for this plugin!

P.-S. The spoilers styles were removed, is that something you intended to do or a mistake?